### PR TITLE
fix: update devcontainer image to 1-22-bookworm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "podr - Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
 	"customizations": {
 		"vscode": {
 			"settings": {


### PR DESCRIPTION
The \mcr.microsoft.com/devcontainers/javascript-node:1-bookworm\ tag no longer exists on MCR, causing Codespaces prebuild failures:

\\\
Error fetching image details: No manifest found for mcr.microsoft.com/devcontainers/javascript-node:1-bookworm
\\\

Updates the image tag to \1-22-bookworm\ which is current and available.